### PR TITLE
Fix value not being written when section doesn't exist

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,8 @@
 #![deny(clippy::panic)]
 mod error;
 mod read;
+#[cfg(test)]
+mod test_helpers;
 mod write;
 pub use error::Error;
 use std::{ops::Range, str::FromStr};

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,0 +1,50 @@
+#[macro_export]
+macro_rules! assert_eq_preserve_new_lines {
+    ($left:expr, $right:expr $(,)?) => ({
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    panic!(
+                        indoc::indoc!("\
+                            Assertion failed
+                            Expected:
+                            ```
+                            {}
+                            ```
+                            Got:
+                            ```
+                            {}
+                            ```"
+                        ),
+                        *right_val,
+                        *left_val,
+                    )
+                }
+            }
+        }
+    });
+    ($left:expr, $right:expr, $($arg:tt)+) => ({
+        match (&$left, &$right) {
+            (left_val, right_val) => {
+                if !(*left_val == *right_val) {
+                    panic!(
+                        indoc::indoc!("\
+                            Assertion failed: {}
+                            Expected:
+                            ```
+                            {}
+                            ```
+                            Got:
+                            ```
+                            {}
+                            ```"
+                        ),
+                        format_args!($($arg)+),
+                        *right_val,
+                        *left_val,
+                    )
+                }
+            }
+        }
+    });
+}


### PR DESCRIPTION
Missed a condition where files that didn't contain the section wouldn't write the value to the new file. Added tests for this.